### PR TITLE
add missing error code context

### DIFF
--- a/src/jshint.js
+++ b/src/jshint.js
@@ -365,6 +365,7 @@ var JSHINT = (function() {
       character: token.from,
       message: message + " (" + percentage + "% scanned).",
       raw: message,
+      code: code,
       a: a,
       b: b
     };
@@ -6523,6 +6524,7 @@ var JSHINT = (function() {
         JSHINT.errors.push({
           scope     : "(main)",
           raw       : err.raw,
+          code      : err.code,
           reason    : err.reason,
           line      : err.line || nt.line,
           character : err.character || nt.from


### PR DESCRIPTION
I believe this accomplishes the goal you were seeking. This is what I did:
```
git@github.com:jugglinmike/jshint-0x005.git
cd jshint-0x005
npm install
npm test
```

The approach I used was thus:
* Isolate test (`./node_modules/nodeunit/bin/nodeunit tests/unit -t testRawOnError`)
* Insert logging line showing JSHINT errors object.
* Find location in codebase where errors are populated.
* Add missing context.

I feel like I'm flying 10,000 feet above the problem you're trying to solve and that I must've missed something (this was too easy).

I hope this is truly all you needed my friend!